### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ LCMosaicImageView is an image view which enables you to add mosaic effect on ima
 
 ### Installation
 
-You can either use Cocoapods, adding `pod 'LCMosaicImageView'` in your podfile, or directly add `LCMosaicImageView.h` and `LCMosaicImageView.m` to your project.
+You can either use CocoaPods, adding `pod 'LCMosaicImageView'` in your podfile, or directly add `LCMosaicImageView.h` and `LCMosaicImageView.m` to your project.
 
 ### Usage
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
